### PR TITLE
Fix importing into svelte project

### DIFF
--- a/packages/bytemd/package.json
+++ b/packages/bytemd/package.json
@@ -17,6 +17,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "svelte": "./svelte/index.js",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
Missing export would cause SvelteKit projects to try to import the _compiled_ component (i.e. the vanilla JS version) instead of the svelte component. It could be used by creating a small `use:bytemd` action to mount it in a `<div>` but it's easier to use the component as intended.

Fixes #11
Fixes #14
Fixes #31