### PR TITLE
fix small scrolling issue

### DIFF
--- a/packages/bytemd/src/editor.svelte
+++ b/packages/bytemd/src/editor.svelte
@@ -434,6 +434,12 @@
         on:click={(e) => {
           const headings = previewEl.querySelectorAll('h1,h2,h3,h4,h5,h6')
           headings[e.detail].scrollIntoView()
+
+          // scroll the editor as well
+          editor.scrollIntoView({
+            line: e.detail+1,
+            ch:0
+          })
         }}
         visible={sidebar === 'toc'}
       />


### PR DESCRIPTION
#50 
fix a small scrolling issue which occurs when trying to scroll the corresponding header into view by clicking the toc while the preview area is hidden.